### PR TITLE
adds Enums documenting role and URL keys

### DIFF
--- a/hrs-portlets-api/pom.xml
+++ b/hrs-portlets-api/pom.xml
@@ -32,7 +32,15 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
-        
+
+
+        <!-- ===== Test Dependencies ====================================== -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     
     <build>

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRole.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRole.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to Jasig under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
@@ -17,28 +17,26 @@
  * under the License.
  */
 
-package edu.wisc.hr.dao.url;
-
-import java.util.Map;
+package edu.wisc.hr.dao.roles;
 
 /**
- * Gets a set of deep-links into the HRS system
- * 
- * @author Eric Dalquist
- * @version $Revision: 1.1 $
+ * Constants representing the roles recognized by the accompanying portlet.
+ * Defines keys suitable for use in HrsRoleDao.
  */
-public interface HrsUrlDao {
+public enum HrsRole {
 
+    // TODO: add comments documenting the meaning of each role.
 
+    ROLE_VIEW_ABSENCE_HISTORIES(),
 
-    /**
-     * Map from expected keys identifying URLs to Strings representing those URLs.
-     * The value Strings should be ready-to-render-to-users URLs, i.e., exactly what you want the hyperlink
-     * target URL to be.
-     *
-     * Expected keys are documented as static fields on this class.
-     *
-     * @return a non-null Map from out-of-band defined String keys to Strings representing the URL values
-     */
-    public Map<String, String> getHrsUrls();
+    ROLE_VIEW_MANAGED_ABSENCES(),
+
+    ROLE_VIEW_MANAGED_TIMES(),
+
+    ROLE_VIEW_TIME_SHEET(),
+
+    ROLE_VIEW_TIME_CLOCK(),
+
+    ROLE_VIEW_WEB_CLOCK();
+
 }

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRolesDao.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/roles/HrsRolesDao.java
@@ -29,5 +29,20 @@ import java.util.Set;
  */
 public interface HrsRolesDao {
 
+
+    /**
+     * Get the Set of roles applicable to the user identified by the provided emplId String.
+     * Roles recognized by this software are represented in HrsRole.
+     *
+     * While this returns a Set of Strings rather than of HrsRole s, the meaningful Strings
+     * are documented in the HrsRole enum.
+     *
+     * Implementations may return Strings not represented in the HrsRole enum.  Callers must cope with the Set
+     * including Strings not represented in the HrsRole enum.  So handle that IllegalArgumentException on
+     * HrsRole.valueOf() if you use it.
+     *
+     * @param emplId employee identifier identifying the user whose roles are queried
+     * @return a potentially empty non-null Set of Strings representing the user's roles
+     */
     public Set<String> getHrsRoles(String emplId);
 }

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrl.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrl.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.hr.dao.url;
+
+/**
+ * Constants representing the keys of URLs recognized by the accompanying portlet.
+ * Defines keys suitable for use in HrsUrlDao.
+ *
+ * WARNING: This enum does not work the way you might expect in that HrsUrl.valueOf(String) is broken.
+ * Use HrsUrlHelper.valueOf(String) instead.  See also accompanying unit test.
+ */
+public enum HrsUrl {
+
+    // TODO: add comments documenting the intended meaning/usage of each URL key
+
+    APPROVE_ABSENCE("Approve Absence"),
+
+    APPROVE_PAYABLE_TIME("Approve Payable time"),
+
+    /**
+     * URL to benefits enrollment.
+     * Presence of this key in the Map causes the portlet to present a link inviting user to a benefit enrollment
+     * opportunity (so only include if there actually might be such an opportunity).
+     */
+    BENEFITS_ENROLLMENT("Benefits Enrollment"),
+
+    BENEFITS_SUMMARY("Benefits Summary"),
+
+    DEPENDENT_COVERAGE("Dependent Coverage"),
+
+    DEPENDENT_INFORMATION("Dependent Information"),
+
+    OPEN_ENROLLMENT_HIRE_EVENT("Open Enrollment/Hire Event"),
+
+    PERSONAL_INFORMATION("Personal Information"),
+
+    REQUEST_ABSENCE("Request Absence"),
+
+    TIME_MANAGEMENT("Time Management"),
+
+    TIMESHEET("Timesheet"),
+
+    UPDATE_TSA_DEDUCTIONS("Update TSA Deductions"),
+
+    PAYABLE_TIME_DETAIL("Payable time detail"),
+
+    TIME_EXCEPTIONS("Time Exceptions"),
+
+    WEB_CLOCK("Web Clock");
+
+    /**
+     * In practice there are "magic String" URL keys that HrsUrlDao implementations use to communicate HRS URLs
+     * from DAO implementation to relying portlet.  These magic Strings have been harvested from the portlet
+     * implementation code.  Alas they do not match the names of the enum instances.
+     */
+    private String code;
+
+    private HrsUrl(String s) {
+        this.code = s;
+    }
+
+    /**
+     * Get the String representation of the HrsUrl enum instance, which is *not* reliably the literal name of the enum.
+     * (As of this writing the enum name and the code never match, but this API definition is not intended to specify
+     * that the names and codes must not match.)
+     * @return the String key actually used to represent the URL key.
+     */
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String toString() {
+        return code;
+    }
+
+
+}

--- a/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrlHelper.java
+++ b/hrs-portlets-api/src/main/java/edu/wisc/hr/dao/url/HrsUrlHelper.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.hr.dao.url;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Static helper implementing HrsUrl.valueOf() enum resolution behavior since HrsUrl.valueOf() does the wrong thing.
+ */
+public final class HrsUrlHelper {
+
+    /**
+     * Private constructor to prevent instantiation of this static helper class.
+     */
+    private HrsUrlHelper() {
+        // do nothing; nothing will ever call this.
+    }
+
+
+    private static Map<String, HrsUrl> CODE_TO_HRS_URLS = new HashMap();
+
+    static {
+
+        for (HrsUrl hrsUrl : HrsUrl.values()) {
+            CODE_TO_HRS_URLS.put(hrsUrl.getCode(), hrsUrl);
+        }
+
+    }
+
+    /**
+     * Converts from a String to the corresponding HrsUrl, with semantics similar to Enum.valueOf(String).
+     *
+     * Corresponding means the HrsUrl getCode() returns *exactly* the representation.
+     *
+     * @param representation a code of a known HrsUrl
+     * @return the corresponding HrsUrl
+     * @throws IllegalArgumentException if the representation is not recognized
+     * @throws NullPointerException if the representation is null
+     */
+    public static HrsUrl valueOf(String representation)
+        throws IllegalArgumentException, NullPointerException {
+
+        if (representation == null) {
+            throw new NullPointerException("Can't get the HrsUrl value of null.");
+        }
+
+        if ( !(CODE_TO_HRS_URLS.containsKey(representation)) ) {
+            throw new IllegalArgumentException("[" + representation + "] is not a recognized representation of an " +
+                    "HrsUrl");
+        }
+
+        return CODE_TO_HRS_URLS.get(representation);
+
+    }
+}

--- a/hrs-portlets-api/src/test/java/edu/wisc/hr/dao/roles/HrsRoleTest.java
+++ b/hrs-portlets-api/src/test/java/edu/wisc/hr/dao/roles/HrsRoleTest.java
@@ -1,0 +1,44 @@
+package edu.wisc.hr.dao.roles;
+
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit test demonstrating the Java Enum language feature in the context of enum HrsRole.
+ *
+ * There's nothing interesting about this unit test because there's nothing interesting about the
+ * HrsRole enum.  This unit test is intended to demonstrate Java language features for working with the Enum
+ * since the intention is that API implementors and API users use the Enum to coordinate role naming.
+ */
+public class HrsRoleTest {
+
+    /**
+     * Demonstrates how one is intended to resolve the role key String at runtime from an HrsRole enum.
+     */
+    @Test
+    public void hrsRolesHaveSensibleToStrings() {
+
+        // you can get the String representation out of an HrsRole.
+        assertEquals("ROLE_VIEW_WEB_CLOCK", HrsRole.ROLE_VIEW_WEB_CLOCK.toString());
+
+        // you can get an HrsRole out of a String representation (that, say, came from an HRS system web service)
+        assertEquals(HrsRole.ROLE_VIEW_MANAGED_ABSENCES, HrsRole.valueOf("ROLE_VIEW_MANAGED_ABSENCES"));
+
+    }
+
+    /**
+     * Demonstrates a heads up to HRS API implementation developers that valueOf() will throw if you
+     * invent a role not recognized by the API.
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void valueOfThrowsWhenNotFound() {
+
+        // of you try to get an HrsRole out of a String representation not recognized by the HrsRole enum
+        // then you get to handle an IllegalArgumentException.
+        HrsRole.valueOf("NON_EXISTENT_BOGUS_ROLE");
+
+    }
+
+}

--- a/hrs-portlets-api/src/test/java/edu/wisc/hr/dao/url/HrsUrlHelperTest.java
+++ b/hrs-portlets-api/src/test/java/edu/wisc/hr/dao/url/HrsUrlHelperTest.java
@@ -1,0 +1,41 @@
+package edu.wisc.hr.dao.url;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test cases demonstrating that HrsUrlHelper.valueOf() has same semantics as HrsUrl.valueOf() should have had were
+ * HrsUrl keys proper Enum-style values.
+ */
+public class HrsUrlHelperTest {
+
+    /**
+     * Test that HrsUrl.valueOf() successfully resolves HrsUrls from their String code representations.
+     */
+    @Test
+    public void testResolvesHrsUrl(){
+
+        assertEquals(HrsUrl.OPEN_ENROLLMENT_HIRE_EVENT, HrsUrlHelper.valueOf("Open Enrollment/Hire Event"));
+
+        assertEquals(HrsUrl.REQUEST_ABSENCE, HrsUrlHelper.valueOf("Request Absence"));
+
+    }
+
+    /**
+     * Test that HrsUrl.valueOf() throws NPE when passed null.
+     */
+    @Test(expected = NullPointerException.class)
+    public void testThrowsNullPointerExceptionOnNullArgument() {
+        HrsUrlHelper.valueOf(null);
+    }
+
+    /**
+     * Test that HrsUrlHelper.valueOf() throws IllegalArgumentException when asked to resolve a String it does not
+     * recognize.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testThrowsIllegalArgumentExceptionOnUnrecognizedKey() {
+        HrsUrlHelper.valueOf("BogusNonExistentUrlIdentifier");
+    }
+}

--- a/hrs-portlets-api/src/test/java/edu/wisc/hr/dao/url/HrsUrlTest.java
+++ b/hrs-portlets-api/src/test/java/edu/wisc/hr/dao/url/HrsUrlTest.java
@@ -1,0 +1,39 @@
+package edu.wisc.hr.dao.url;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit tests documenting the getCode() feature of HrsUrl and that HrsUrl.valueOf() is not what one would want it to
+ * be.  See also HrsUrlHelper for usable valueOf(String) behavior.
+ */
+public class HrsUrlTest {
+
+    /**
+     * Test that the String representation of an HrsUrl is its String representation "code" as used by the known
+     * HrsUrlDao implementations rather than just the literal name of the enum instance.
+     */
+    @Test
+    public void testHrsUrlsToStringToTheirCodes() {
+
+        assertEquals("Approve Payable time", HrsUrl.APPROVE_PAYABLE_TIME.toString());
+
+    }
+
+    @Test
+    public void testHrsUrlsGetCode() {
+        assertEquals("Benefits Summary", HrsUrl.BENEFITS_SUMMARY.getCode());
+    }
+
+    /**
+     * Heads up, this is important.  HrsUrl.valueOf() doesn't work the way one expects in enums because the
+     * pre-established Url key values are goofy Strings that aren't usable as names of HrsUrl enum instances.
+     *
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testValueOf() {
+        HrsUrl.valueOf("Open Enrollment/Hire Event");
+    }
+
+}


### PR DESCRIPTION
Documents in the role and URL DAO interfaces the role and URL keys expected by the HRS portlets.

This is in support of creating additional implementations of these DAOs.
