### PR TITLE
configures the maven-war-plugin to useCache

### DIFF
--- a/hrs-portlets-webapp/pom.xml
+++ b/hrs-portlets-webapp/pom.xml
@@ -229,6 +229,7 @@
                             <artifactId>datalist-portlet-content</artifactId>
                         </overlay>
                     </overlays>
+                    <useCache>true</useCache>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Turns on caching of the web app structure across builds.
I don’t actually understand this, but Google search results vaguely suggest this might resolve the current build failure.
