### PR TITLE
Upgrades to jasig-parent v36 (from v34) and configures maven-war-plugin to useCache

### DIFF
--- a/hrs-portlets-webapp/pom.xml
+++ b/hrs-portlets-webapp/pom.xml
@@ -229,6 +229,7 @@
                             <artifactId>datalist-portlet-content</artifactId>
                         </overlay>
                     </overlays>
+                    <useCache>true</useCache>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jasig.parent</groupId>
         <artifactId>jasig-parent</artifactId>
-        <version>34</version>
+        <version>36</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
The combination of bumping the `jasig-parent` version and adding `useCache` makes `travis-ci` build work.
