### PR TITLE
Use user.login.id as emplid

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,57 @@ Several property files need to be configured for your local environment before t
 	* Copy EXAMPLE_ps-placeholder.properties to **ps-placeholder.properties**
 	* Do Not add ps-placeholder.properties to source control (should be automatically ignored via local .gitignore)
 
+## Declaring the employee-id-conveying user attribute
+
+The HRS Portlets need the logged in user's identifier for communicating about the user with the backing HRS systems.  The portlets get this identifier from the portal as one or more user attributes.  You'll need to both tell the portlets what user identifier to use and tell the portal to release those user attributes to the portlets.
+
+### Telling the portlet what attribute to use
+
+There's a `emplidUserAttributes` portlet preference, multi-valued, the values of which are the names of user attributes the portlet should look in to resolve emplId.  The demo default simply uses `user.login.id` which should always be available.  
+
+That's probably not your HRS identifier though.  The University of Wisconsin-Madison's value for this preference looks more like this to cope with the multi-campus nature of the portal:
+
+    <portlet-preferences>
+      <preference>
+        <name>emplidUserAttributes</name>
+
+        <!-- the value or values here should be the user attributes providing HRS system user identifiers -->
+        <value>eduWisconsinHRSEmplID</value>
+        <value>eduWisconsinHRPersonID</value>
+        <value>wiscEduHRSEmplid</value>
+        <value>wisceduhrpersonid</value>
+        
+      </preference>
+    </portlet-preferences>
+
+(Ideally your portal configuration and identity management processes will digest this down to one simple attribute for your portal to feed to your portlets.)
+
+You'll need to do this within *each* portlet declaration in `portlet.xml`, since each of the portlets uses this preference to figure out how to resolve the HRS employee identifier.
+
+### Telling the portal to release the attributes to the portlet
+
+Also in `portlet.xml` you'll need to declare the user attributes relied upon by your portlets.  These will be the user attributes you just told the portlets to look at in setting that `emplidUserAttributes` preference.
+
+The University of Wisconsin-Madison's user-attribute declarations are something like this:
+
+    <user-attribute>
+      <name>eduWisconsinHRSEmplID</name>
+     </user-attribute>
+     <user-attribute>
+       <name>eduWisconsinHRPersonID</name>
+     </user-attribute>
+     <user-attribute>
+       <name>wiscEduHRSEmplid</name>
+     </user-attribute>
+     <user-attribute>
+       <name>wisceduhrpersonid</name>
+     </user-attribute>
+
+Again, ideally carefully considered identity and portal management will have pre-digested this down to one simple attribute to feed to this portlet so you'll only be declaring one `user-attribute`.
+
+
+
+
 
 [Travis-CI.org]: https://travis-ci.org/Jasig/hrs-portlets
 [the github page]: https://github.com/Jasig/hrs-portlets

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## ReadMe
+# ReadMe
 
-### Continuous Integration Status
+## Continuous Integration Status
 
 This project uses [Travis-CI.org][] for continuous integration.  This means that every commit to `master` and every
 Pull Request is automatically built and the unit tests are automatically run.  The below badge shows the current status
@@ -10,7 +10,9 @@ README locally. :) )
 ![Build Status](https://travis-ci.org/Jasig/hrs-portlets.png?branch=master)
 
 
-### Local Setup Instructions
+## Local Setup Instructions
+
+### Property files
 
 Several property files need to be configured for your local environment before the Portlet will run in your local uPortal server.
 

--- a/hrs-portlets-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/hrs-portlets-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -43,11 +43,8 @@
         <portlet-preferences>
             <preference>
               <name>emplidUserAttributes</name>
-              <value>eduWisconsinHRSEmplID</value>
-              <value>eduWisconsinHRPersonID</value>
-              <value>wiscEduHRSEmplid</value>
-              <value>wisceduhrpersonid</value>
-              <value>legacywisceduhrpersonid</value>
+              <!-- the value or values here should be the user attributes providing HRS system user identifiers -->
+              <value>user.login.id</value>
             </preference>
         </portlet-preferences>
     </portlet>
@@ -71,11 +68,8 @@
         <portlet-preferences>
             <preference>
               <name>emplidUserAttributes</name>
-              <value>eduWisconsinHRSEmplID</value>
-              <value>eduWisconsinHRPersonID</value>
-              <value>wiscEduHRSEmplid</value>
-              <value>wisceduhrpersonid</value>
-              <value>legacywisceduhrpersonid</value>
+              <!-- the value or values here should be the user attributes providing HRS system user identifiers -->
+              <value>user.login.id</value>
             </preference>
         </portlet-preferences>
     </portlet>
@@ -99,11 +93,8 @@
         <portlet-preferences>
             <preference>
               <name>emplidUserAttributes</name>
-              <value>eduWisconsinHRSEmplID</value>
-              <value>eduWisconsinHRPersonID</value>
-              <value>wiscEduHRSEmplid</value>
-              <value>wisceduhrpersonid</value>
-              <value>legacywisceduhrpersonid</value>
+              <!-- the value or values here should be the user attributes providing HRS system user identifiers -->
+              <value>user.login.id</value>
             </preference>
         </portlet-preferences>
     </portlet>
@@ -127,11 +118,8 @@
         <portlet-preferences>
             <preference>
               <name>emplidUserAttributes</name>
-              <value>eduWisconsinHRSEmplID</value>
-              <value>eduWisconsinHRPersonID</value>
-              <value>wiscEduHRSEmplid</value>
-              <value>wisceduhrpersonid</value>
-              <value>legacywisceduhrpersonid</value>
+              <!-- the value or values here should be the user attributes providing HRS system user identifiers -->
+              <value>user.login.id</value>
             </preference>
         </portlet-preferences>
     </portlet>
@@ -160,11 +148,8 @@
             </preference>
             <preference>
               <name>emplidUserAttributes</name>
-              <value>eduWisconsinHRSEmplID</value>
-              <value>eduWisconsinHRPersonID</value>
-              <value>wiscEduHRSEmplid</value>
-              <value>wisceduhrpersonid</value>
-              <value>legacywisceduhrpersonid</value>
+              <!-- the value or values here should be the user attributes providing HRS system user identifiers -->
+              <value>user.login.id</value>
             </preference>
         </portlet-preferences>
     </portlet>
@@ -188,29 +173,14 @@
         <portlet-preferences>
             <preference>
               <name>emplidUserAttributes</name>
-              <value>eduWisconsinHRSEmplID</value>
-              <value>eduWisconsinHRPersonID</value>
-              <value>wiscEduHRSEmplid</value>
-              <value>wisceduhrpersonid</value>
-              <value>legacywisceduhrpersonid</value>
+              <!-- the value or values here should be the user attributes providing HRS system user identifiers -->
+              <value>user.login.id</value>
             </preference>
         </portlet-preferences>
     </portlet>
     
     <user-attribute>
-        <name>eduWisconsinHRSEmplID</name>
-    </user-attribute>
-    <user-attribute>
-        <name>eduWisconsinHRPersonID</name>
-    </user-attribute>
-    <user-attribute>
-        <name>wiscEduHRSEmplid</name>
-    </user-attribute>
-    <user-attribute>
-        <name>wisceduhrpersonid</name>
-    </user-attribute>
-    <user-attribute>
-        <name>legacywisceduhrpersonid</name>
+        <name>user.login.id</name>
     </user-attribute>
     
     <filter>


### PR DESCRIPTION
Reduces needless Wisconsin-specific-ness and makes the portlets slightly closer to local-deploy-ready by switching to use the ubiquitous `user.login.id` as the default user attribute to use as the source for the employee identifier.

Credit to @jameswennmacher for articulating this improvement; see also discussion at https://lists.wisc.edu/read/messages?id=32053450 .
